### PR TITLE
[FIX] Fix Rate limiting issue

### DIFF
--- a/api/app/app/main.py
+++ b/api/app/app/main.py
@@ -6,7 +6,6 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.router import api_router
 from app.config import settings
-from app.core.rate_limit import RateLimitMiddleware
 
 
 @asynccontextmanager
@@ -37,7 +36,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.add_middleware(RateLimitMiddleware, requests_per_minute=120)
 app.include_router(api_router, prefix="")
 
 


### PR DESCRIPTION
This pull request removes the `RateLimitMiddleware` from the FastAPI application, meaning that rate limiting is no longer enforced at the application level.

- Middleware removal:
  * Removed the import of `RateLimitMiddleware` from `app.core.rate_limit` and its addition to the FastAPI middleware stack in `main.py`, disabling the previous rate limiting of 120 requests per minute. [[1]](diffhunk://#diff-070d271793a77ba570cbe8ad7b3e06b238876065f312525d134615b26d93d2c0L9) [[2]](diffhunk://#diff-070d271793a77ba570cbe8ad7b3e06b238876065f312525d134615b26d93d2c0L40)