### PR TITLE
feat: sync image files

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loomy",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loomy",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.0",
         "@tailwindcss/vite": "^4.2.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loomy",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/frontend/src/hooks/useBoardCollab.ts
+++ b/apps/frontend/src/hooks/useBoardCollab.ts
@@ -6,7 +6,9 @@ import {
   PERSISTENCE_LOAD_ORIGIN,
   REMOTE_ORIGIN,
   applyElementsToYMap,
+  applyElementsToYMapInner,
   applyFilesToYMap,
+  applyFilesToYMapInner,
   readElementsFromYMap,
   readFilesFromYMap,
   type ElementJson,
@@ -154,14 +156,16 @@ export function useBoardCollab(
   // so a peer never sees an image element whose fileId hasn't been
   // populated in the files map yet (which renders the image as a
   // pending placeholder Excalidraw won't let you interact with).
+  // Calls the *Inner helpers (no nested transacts) so this is the
+  // single place that defines the transaction boundary and origin.
   const syncLocalChanges = useCallback(
     (
       elements: readonly ElementJson[],
       files: Readonly<Record<string, FileJson>> | null | undefined,
     ) => {
       doc.transact(() => {
-        if (files) applyFilesToYMap(doc, yfiles, files);
-        applyElementsToYMap(doc, ymap, elements);
+        if (files) applyFilesToYMapInner(yfiles, files);
+        applyElementsToYMapInner(ymap, elements);
       }, LOCAL_ORIGIN);
     },
     [doc, ymap, yfiles],

--- a/apps/frontend/src/hooks/useBoardCollab.ts
+++ b/apps/frontend/src/hooks/useBoardCollab.ts
@@ -6,8 +6,11 @@ import {
   PERSISTENCE_LOAD_ORIGIN,
   REMOTE_ORIGIN,
   applyElementsToYMap,
+  applyFilesToYMap,
   readElementsFromYMap,
+  readFilesFromYMap,
   type ElementJson,
+  type FileJson,
 } from "@/lib/collab/yjs-bridge";
 import { decodeYjsUpdate, encodeYjsDoc } from "@/lib/collab/yjs-persistence";
 import {
@@ -20,6 +23,7 @@ export interface UseBoardCollabOptions extends Omit<
   "onRemoteBinary"
 > {
   onRemoteElements?: (elements: ElementJson[]) => void;
+  onRemoteFiles?: (files: FileJson[]) => void;
 }
 
 export function useBoardCollab(
@@ -27,11 +31,15 @@ export function useBoardCollab(
   token: string | null,
   options: UseBoardCollabOptions = {},
 ) {
-  const { onRemoteElements, ...wsOptions } = options;
+  const { onRemoteElements, onRemoteFiles, ...wsOptions } = options;
   const onRemoteElementsRef = useRef(onRemoteElements);
+  const onRemoteFilesRef = useRef(onRemoteFiles);
   useEffect(() => {
     onRemoteElementsRef.current = onRemoteElements;
   }, [onRemoteElements]);
+  useEffect(() => {
+    onRemoteFilesRef.current = onRemoteFiles;
+  }, [onRemoteFiles]);
 
   // boardId is the dependency even though the factory doesn't read it:
   // changing boards must produce a fresh Y.Doc.
@@ -44,6 +52,7 @@ export function useBoardCollab(
   }, [doc]);
 
   const ymap = useMemo(() => doc.getMap<ElementJson>("elements"), [doc]);
+  const yfiles = useMemo(() => doc.getMap<FileJson>("files"), [doc]);
 
   // Per-user undo scope: only the local client's edits are in the stack.
   // Remote edits don't end up on our undo history — you can only undo
@@ -109,11 +118,58 @@ export function useBoardCollab(
     };
   }, [ymap]);
 
+  useEffect(() => {
+    const observer = (event: Y.YMapEvent<FileJson>) => {
+      if (event.transaction.origin === LOCAL_ORIGIN) return;
+      const added: FileJson[] = [];
+      for (const id of event.keysChanged) {
+        const f = yfiles.get(id);
+        if (f) added.push(f);
+      }
+      if (added.length > 0) onRemoteFilesRef.current?.(added);
+    };
+    yfiles.observe(observer);
+    return () => {
+      yfiles.unobserve(observer);
+    };
+  }, [yfiles]);
+
   const syncLocalElements = useCallback(
     (elements: readonly ElementJson[]) => {
       applyElementsToYMap(doc, ymap, elements);
     },
     [doc, ymap],
+  );
+
+  const syncLocalFiles = useCallback(
+    (files: Readonly<Record<string, FileJson>> | null | undefined) => {
+      if (!files) return;
+      applyFilesToYMap(doc, yfiles, files);
+    },
+    [doc, yfiles],
+  );
+
+  // Combined writer used by the canvas onChange handler. One outer
+  // transact means files + elements travel as a single Yjs update,
+  // so a peer never sees an image element whose fileId hasn't been
+  // populated in the files map yet (which renders the image as a
+  // pending placeholder Excalidraw won't let you interact with).
+  const syncLocalChanges = useCallback(
+    (
+      elements: readonly ElementJson[],
+      files: Readonly<Record<string, FileJson>> | null | undefined,
+    ) => {
+      doc.transact(() => {
+        if (files) applyFilesToYMap(doc, yfiles, files);
+        applyElementsToYMap(doc, ymap, elements);
+      }, LOCAL_ORIGIN);
+    },
+    [doc, ymap, yfiles],
+  );
+
+  const readAllFiles = useCallback(
+    (): FileJson[] => readFilesFromYMap(yfiles),
+    [yfiles],
   );
 
   const seedFromSnapshot = useCallback(
@@ -143,6 +199,9 @@ export function useBoardCollab(
   return {
     ...ws,
     syncLocalElements,
+    syncLocalFiles,
+    syncLocalChanges,
+    readAllFiles,
     seedFromSnapshot,
     encodeYjsState,
     applyYjsState,

--- a/apps/frontend/src/hooks/useBoardContent.ts
+++ b/apps/frontend/src/hooks/useBoardContent.ts
@@ -6,6 +6,9 @@ const SNAPSHOT_TYPE = "excalidraw_snapshot";
 export type ExcalidrawSnapshot = {
   elements?: readonly unknown[] | null;
   appState?: Readonly<Record<string, unknown>> | null;
+  // Image blobs keyed by Excalidraw fileId. Image elements only carry
+  // a fileId reference, so without this map the image renders blank.
+  files?: Readonly<Record<string, unknown>> | null;
   // Authoritative shared state when present (base64 Yjs update).
   // Legacy boards have only `elements`/`appState`.
   yjs_update?: string | null;

--- a/apps/frontend/src/lib/collab/yjs-bridge.test.ts
+++ b/apps/frontend/src/lib/collab/yjs-bridge.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import * as Y from "yjs";
 import {
   applyElementsToYMap,
+  applyFilesToYMap,
   readElementsFromYMap,
+  readFilesFromYMap,
   type ElementJson,
+  type FileJson,
 } from "./yjs-bridge";
 
 function makeDoc() {
@@ -114,6 +117,168 @@ describe("in-place element mutation (regression: 'only a dot' bug)", () => {
     applyElementsToYMap(doc, ymap, [el]);
     el.versionNonce = 999;
     expect(ymap.get("x")?.versionNonce).toBe(1);
+  });
+});
+
+describe("echo suppression (regression: peer's drag snaps back)", () => {
+  it("does not write when only versionNonce changed but content is identical", () => {
+    const { doc, ymap } = makeDoc();
+    applyElementsToYMap(doc, ymap, [
+      { id: "x", versionNonce: 1, x: 100, y: 100 },
+    ]);
+
+    let updates = 0;
+    doc.on("update", () => updates++);
+    // Excalidraw bumps versionNonce while applying an inbound scene update
+    // even though the visible state is unchanged. Without echo suppression
+    // we'd write this back to the peer mid-drag.
+    applyElementsToYMap(doc, ymap, [
+      { id: "x", versionNonce: 999, x: 100, y: 100 },
+    ]);
+    expect(updates).toBe(0);
+  });
+
+  it("still writes when content actually changed (different x/y)", () => {
+    const { doc, ymap } = makeDoc();
+    applyElementsToYMap(doc, ymap, [
+      { id: "x", versionNonce: 1, x: 100, y: 100 },
+    ]);
+
+    let updates = 0;
+    doc.on("update", () => updates++);
+    applyElementsToYMap(doc, ymap, [
+      { id: "x", versionNonce: 2, x: 200, y: 100 },
+    ]);
+    expect(updates).toBeGreaterThan(0);
+    expect(ymap.get("x")?.x).toBe(200);
+  });
+
+  it("ignores `version` field drift the same way", () => {
+    const { doc, ymap } = makeDoc();
+    applyElementsToYMap(doc, ymap, [
+      { id: "x", versionNonce: 1, version: 1, x: 0 },
+    ]);
+
+    let updates = 0;
+    doc.on("update", () => updates++);
+    applyElementsToYMap(doc, ymap, [
+      { id: "x", versionNonce: 2, version: 5, x: 0 },
+    ]);
+    expect(updates).toBe(0);
+  });
+
+  it("ignores `updated` timestamp drift (the field Excalidraw bumps when applying inbound updateScene)", () => {
+    const { doc, ymap } = makeDoc();
+    applyElementsToYMap(doc, ymap, [
+      { id: "x", versionNonce: 1, updated: 1000, x: 50 },
+    ]);
+
+    let updates = 0;
+    doc.on("update", () => updates++);
+    applyElementsToYMap(doc, ymap, [
+      { id: "x", versionNonce: 2, updated: 9999, x: 50 },
+    ]);
+    expect(updates).toBe(0);
+  });
+
+  it("ignores `seed` drift", () => {
+    const { doc, ymap } = makeDoc();
+    applyElementsToYMap(doc, ymap, [
+      { id: "x", versionNonce: 1, seed: 111, x: 0 },
+    ]);
+
+    let updates = 0;
+    doc.on("update", () => updates++);
+    applyElementsToYMap(doc, ymap, [
+      { id: "x", versionNonce: 2, seed: 222, x: 0 },
+    ]);
+    expect(updates).toBe(0);
+  });
+
+  it("simulates the full peer-drag echo path: B drags, A's stamp comes back, B holds", () => {
+    // Models the snap-back bug end-to-end inside one doc.
+    const { doc, ymap } = makeDoc();
+    // Initial state: image at x=100.
+    applyElementsToYMap(doc, ymap, [
+      { id: "img", versionNonce: 1, version: 1, updated: 1000, x: 100, y: 0 },
+    ]);
+
+    // Peer B drags it to x=200 (real change).
+    applyElementsToYMap(doc, ymap, [
+      { id: "img", versionNonce: 2, version: 2, updated: 2000, x: 200, y: 0 },
+    ]);
+    expect(ymap.get("img")?.x).toBe(200);
+
+    // Peer A's Excalidraw applied that update via updateScene, then
+    // fired onChange with the same x=200 but with version/nonce/updated
+    // re-stamped. The bridge MUST NOT echo this back.
+    let updates = 0;
+    doc.on("update", () => updates++);
+    applyElementsToYMap(doc, ymap, [
+      { id: "img", versionNonce: 3, version: 3, updated: 3000, x: 200, y: 0 },
+    ]);
+    expect(updates).toBe(0);
+    expect(ymap.get("img")?.x).toBe(200);
+  });
+});
+
+describe("applyFilesToYMap", () => {
+  function makeFilesDoc() {
+    const doc = new Y.Doc();
+    const ymap = doc.getMap<FileJson>("files");
+    return { doc, ymap };
+  }
+
+  it("inserts files keyed by id", () => {
+    const { doc, ymap } = makeFilesDoc();
+    applyFilesToYMap(doc, ymap, {
+      f1: { id: "f1", dataURL: "data:a", mimeType: "image/png" },
+      f2: { id: "f2", dataURL: "data:b", mimeType: "image/png" },
+    });
+    expect(ymap.size).toBe(2);
+    expect(ymap.get("f1")?.dataURL).toBe("data:a");
+  });
+
+  it("never overwrites an existing entry by the same id", () => {
+    const { doc, ymap } = makeFilesDoc();
+    applyFilesToYMap(doc, ymap, {
+      f1: { id: "f1", dataURL: "data:a" },
+    });
+    applyFilesToYMap(doc, ymap, {
+      f1: { id: "f1", dataURL: "data:OVERWRITE" },
+    });
+    expect(ymap.get("f1")?.dataURL).toBe("data:a");
+  });
+
+  it("does not delete files missing from the input (insert-only)", () => {
+    const { doc, ymap } = makeFilesDoc();
+    applyFilesToYMap(doc, ymap, {
+      f1: { id: "f1", dataURL: "data:a" },
+      f2: { id: "f2", dataURL: "data:b" },
+    });
+    applyFilesToYMap(doc, ymap, {
+      f1: { id: "f1", dataURL: "data:a" },
+    });
+    expect(ymap.has("f2")).toBe(true);
+  });
+
+  it("ignores entries without a string id", () => {
+    const { doc, ymap } = makeFilesDoc();
+    applyFilesToYMap(doc, ymap, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      bogus: { dataURL: "x" } as any,
+    });
+    expect(ymap.size).toBe(0);
+  });
+
+  it("syncs files between two docs via Yjs updates", () => {
+    const a = makeFilesDoc();
+    const b = makeFilesDoc();
+    applyFilesToYMap(a.doc, a.ymap, {
+      f1: { id: "f1", dataURL: "data:a" },
+    });
+    Y.applyUpdate(b.doc, Y.encodeStateAsUpdate(a.doc));
+    expect(readFilesFromYMap(b.ymap).map((f) => f.id)).toEqual(["f1"]);
   });
 });
 

--- a/apps/frontend/src/lib/collab/yjs-bridge.ts
+++ b/apps/frontend/src/lib/collab/yjs-bridge.ts
@@ -14,29 +14,39 @@ export const PERSISTENCE_LOAD_ORIGIN: unique symbol = Symbol(
   "loomy-persistence-load",
 );
 
+// Inner: assumes the caller is already inside a Y transaction. Lets the
+// combined writer (`syncLocalChanges`) batch element + file writes into
+// one transaction without nesting.
+export function applyElementsToYMapInner(
+  ymap: Y.Map<ElementJson>,
+  elements: readonly ElementJson[],
+): void {
+  const seen = new Set<string>();
+  for (const el of elements) {
+    if (!el || typeof el.id !== "string") continue;
+    seen.add(el.id);
+    const existing = ymap.get(el.id);
+    if (!existing || !elementsEqual(existing, el)) {
+      // Clone before storing. Y.Map holds the value by reference,
+      // and Excalidraw mutates its own elements in place during drag.
+      // If we stored `el` directly, `existing === el` would make the
+      // diff see no change on the next onChange, so updates would
+      // stop propagating after the first pointer-down.
+      ymap.set(el.id, { ...el });
+    }
+  }
+  for (const id of Array.from(ymap.keys())) {
+    if (!seen.has(id)) ymap.delete(id);
+  }
+}
+
 export function applyElementsToYMap(
   doc: Y.Doc,
   ymap: Y.Map<ElementJson>,
   elements: readonly ElementJson[],
 ): void {
   doc.transact(() => {
-    const seen = new Set<string>();
-    for (const el of elements) {
-      if (!el || typeof el.id !== "string") continue;
-      seen.add(el.id);
-      const existing = ymap.get(el.id);
-      if (!existing || !elementsEqual(existing, el)) {
-        // Clone before storing. Y.Map holds the value by reference,
-        // and Excalidraw mutates its own elements in place during drag.
-        // If we stored `el` directly, `existing === el` would make the
-        // diff see no change on the next onChange, so updates would
-        // stop propagating after the first pointer-down.
-        ymap.set(el.id, { ...el });
-      }
-    }
-    for (const id of Array.from(ymap.keys())) {
-      if (!seen.has(id)) ymap.delete(id);
-    }
+    applyElementsToYMapInner(ymap, elements);
   }, LOCAL_ORIGIN);
 }
 
@@ -53,46 +63,35 @@ export function readElementsFromYMap(ymap: Y.Map<ElementJson>): ElementJson[] {
 
 export type FileJson = Record<string, unknown> & { id: string };
 
+// Inner: see applyElementsToYMapInner for the rationale on the split.
+// Files are insert-only by stable id. Excalidraw retains BinaryFileData
+// blobs even after the referencing image element is deleted, and the
+// local `files` map can transiently lack an entry that was uploaded by
+// another peer — never delete from the shared map on absence, only add.
+export function applyFilesToYMapInner(
+  ymap: Y.Map<FileJson>,
+  files: Readonly<Record<string, FileJson>>,
+): void {
+  for (const id of Object.keys(files)) {
+    const f = files[id];
+    if (!f || typeof f.id !== "string") continue;
+    if (!ymap.has(id)) ymap.set(id, { ...f });
+  }
+}
+
 export function applyFilesToYMap(
   doc: Y.Doc,
   ymap: Y.Map<FileJson>,
   files: Readonly<Record<string, FileJson>>,
 ): void {
-  // Files are insert-only by stable id. Excalidraw retains BinaryFileData
-  // blobs even after the referencing image element is deleted, and the
-  // local `files` map can transiently lack an entry that was uploaded by
-  // another peer — never delete from the shared map on absence, only add.
-  const ids = Object.keys(files);
-  if (ids.length === 0) return;
+  if (Object.keys(files).length === 0) return;
   doc.transact(() => {
-    for (const id of ids) {
-      const f = files[id];
-      if (!f || typeof f.id !== "string") continue;
-      if (!ymap.has(id)) ymap.set(id, { ...f });
-    }
+    applyFilesToYMapInner(ymap, files);
   }, LOCAL_ORIGIN);
 }
 
 export function readFilesFromYMap(ymap: Y.Map<FileJson>): FileJson[] {
   return Array.from(ymap.values());
-}
-
-function elementsEqual(a: ElementJson, b: ElementJson): boolean {
-  // Fast path — matching versionNonce always implies identical content,
-  // so we can skip the structural compare on the hot drag path.
-  if (
-    typeof a.versionNonce === "number" &&
-    typeof b.versionNonce === "number" &&
-    a.versionNonce === b.versionNonce
-  ) {
-    return true;
-  }
-  // Slow path — Excalidraw sometimes bumps an element's version /
-  // versionNonce without changing visible content (e.g. when applying
-  // an inbound updateScene). If we treated those as different, we'd
-  // echo a "no-op" change back to the peer, and that echo lands on
-  // their canvas mid-drag and snaps them back to the pre-drag spot.
-  return canonicalize(a) === canonicalize(b);
 }
 
 // Fields Excalidraw bumps on every "touch" without any user-visible
@@ -108,11 +107,62 @@ const DRIFT_FIELDS: ReadonlySet<string> = new Set([
   "seed",
 ]);
 
-function canonicalize(el: ElementJson): string {
-  const keys = Object.keys(el)
-    .filter((k) => !DRIFT_FIELDS.has(k))
-    .sort();
-  const out: Record<string, unknown> = {};
-  for (const k of keys) out[k] = (el as Record<string, unknown>)[k];
-  return JSON.stringify(out);
+function elementsEqual(a: ElementJson, b: ElementJson): boolean {
+  // Fast path — matching versionNonce always implies identical content,
+  // so we can skip the structural compare on the hot drag path.
+  if (
+    typeof a.versionNonce === "number" &&
+    typeof b.versionNonce === "number" &&
+    a.versionNonce === b.versionNonce
+  ) {
+    return true;
+  }
+  // Slow path — direct walk that ignores drift fields. Short-circuits
+  // on the first real mismatch and never allocates (no JSON.stringify,
+  // no Object.keys, no sort). On the steady drag echo, the walk visits
+  // each non-drift field once and returns true the moment it confirms
+  // they all match.
+  return contentEqual(a, b);
+}
+
+function contentEqual(a: ElementJson, b: ElementJson): boolean {
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  let aCount = 0;
+  for (const k in ao) {
+    if (DRIFT_FIELDS.has(k)) continue;
+    aCount++;
+    if (!deepEqual(ao[k], bo[k])) return false;
+  }
+  let bCount = 0;
+  for (const k of Object.keys(bo)) {
+    if (!DRIFT_FIELDS.has(k)) bCount++;
+  }
+  return aCount === bCount;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  const aArr = Array.isArray(a);
+  const bArr = Array.isArray(b);
+  if (aArr !== bArr) return false;
+  if (aArr) {
+    const arrA = a as unknown[];
+    const arrB = b as unknown[];
+    if (arrA.length !== arrB.length) return false;
+    for (let i = 0; i < arrA.length; i++) {
+      if (!deepEqual(arrA[i], arrB[i])) return false;
+    }
+    return true;
+  }
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+  let countA = 0;
+  for (const k in objA) {
+    countA++;
+    if (!deepEqual(objA[k], objB[k])) return false;
+  }
+  return countA === Object.keys(objB).length;
 }

--- a/apps/frontend/src/lib/collab/yjs-bridge.ts
+++ b/apps/frontend/src/lib/collab/yjs-bridge.ts
@@ -51,12 +51,68 @@ export function readElementsFromYMap(ymap: Y.Map<ElementJson>): ElementJson[] {
   return values;
 }
 
+export type FileJson = Record<string, unknown> & { id: string };
+
+export function applyFilesToYMap(
+  doc: Y.Doc,
+  ymap: Y.Map<FileJson>,
+  files: Readonly<Record<string, FileJson>>,
+): void {
+  // Files are insert-only by stable id. Excalidraw retains BinaryFileData
+  // blobs even after the referencing image element is deleted, and the
+  // local `files` map can transiently lack an entry that was uploaded by
+  // another peer — never delete from the shared map on absence, only add.
+  const ids = Object.keys(files);
+  if (ids.length === 0) return;
+  doc.transact(() => {
+    for (const id of ids) {
+      const f = files[id];
+      if (!f || typeof f.id !== "string") continue;
+      if (!ymap.has(id)) ymap.set(id, { ...f });
+    }
+  }, LOCAL_ORIGIN);
+}
+
+export function readFilesFromYMap(ymap: Y.Map<FileJson>): FileJson[] {
+  return Array.from(ymap.values());
+}
+
 function elementsEqual(a: ElementJson, b: ElementJson): boolean {
+  // Fast path — matching versionNonce always implies identical content,
+  // so we can skip the structural compare on the hot drag path.
   if (
     typeof a.versionNonce === "number" &&
-    typeof b.versionNonce === "number"
+    typeof b.versionNonce === "number" &&
+    a.versionNonce === b.versionNonce
   ) {
-    return a.versionNonce === b.versionNonce;
+    return true;
   }
-  return JSON.stringify(a) === JSON.stringify(b);
+  // Slow path — Excalidraw sometimes bumps an element's version /
+  // versionNonce without changing visible content (e.g. when applying
+  // an inbound updateScene). If we treated those as different, we'd
+  // echo a "no-op" change back to the peer, and that echo lands on
+  // their canvas mid-drag and snaps them back to the pre-drag spot.
+  return canonicalize(a) === canonicalize(b);
+}
+
+// Fields Excalidraw bumps on every "touch" without any user-visible
+// change. `updated` is the epoch ms of the last modification (re-stamped
+// when updateScene applies an inbound element); `version` /
+// `versionNonce` are Excalidraw's own collab-reconciliation cursors;
+// `seed` is for roughjs shape stability and shouldn't drift, but is
+// excluded defensively in case a clone path regenerates it.
+const DRIFT_FIELDS: ReadonlySet<string> = new Set([
+  "version",
+  "versionNonce",
+  "updated",
+  "seed",
+]);
+
+function canonicalize(el: ElementJson): string {
+  const keys = Object.keys(el)
+    .filter((k) => !DRIFT_FIELDS.has(k))
+    .sort();
+  const out: Record<string, unknown> = {};
+  for (const k of keys) out[k] = (el as Record<string, unknown>)[k];
+  return JSON.stringify(out);
 }

--- a/apps/frontend/src/pages/board/BoardPage.tsx
+++ b/apps/frontend/src/pages/board/BoardPage.tsx
@@ -184,25 +184,13 @@ export function BoardPage() {
     [excalidrawAPI],
   );
 
-  // Hoisted via ref so the callback can reach into useBoardCollab's
-  // return value without a forward-reference TDZ — the hook is called
-  // below and consumes onRemoteElements as one of its options.
-  const readAllFilesRef = useRef<(() => FileJson[]) | null>(null);
+  // Files are registered separately via onRemoteFiles (which only
+  // fires for keys actually added to the Y.Doc files map), and via the
+  // initial seedFiles() pass below — so this handler doesn't need to
+  // re-read the whole files map on every drag tick.
   const onRemoteElements = useCallback(
     (elements: ElementJson[]) => {
       if (!excalidrawAPI) return;
-      // Register every known file first. If an image element references
-      // a fileId whose blob hasn't reached this client yet, Excalidraw
-      // marks the element as not-fully-loaded and disables interaction —
-      // the peer who didn't add the image can't move it. addFiles is
-      // idempotent, so calling it on every remote elements update is
-      // safe and only meaningful when a new file actually landed.
-      const files = readAllFilesRef.current?.() ?? [];
-      if (files.length > 0) {
-        excalidrawAPI.addFiles(
-          files as unknown as Parameters<ExcalidrawAPI["addFiles"]>[0],
-        );
-      }
       excalidrawAPI.updateScene({
         elements: elements as unknown as Parameters<
           ExcalidrawAPI["updateScene"]
@@ -239,10 +227,6 @@ export function BoardPage() {
     onRemoteFiles,
     onRemoteEvent: fanoutBoardEvent,
   });
-
-  useEffect(() => {
-    readAllFilesRef.current = readAllFiles;
-  }, [readAllFiles]);
 
   // Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z drive the collab-aware undo stack
   // (only undoes the local user's own ops, not remote ones).
@@ -332,10 +316,12 @@ export function BoardPage() {
   // Keep the latest elements+appState in refs so the deferred getter
   // below can read them at save time without re-encoding the Y.Doc on
   // every pointer move (that ran 60x/sec during drag and was the main
-  // reason the canvas felt sluggish).
+  // reason the canvas felt sluggish). Files are deliberately NOT
+  // mirrored here — they're already encoded inside `yjs_update`, and
+  // duplicating image dataURLs in the saved snapshot would double the
+  // autosave payload on image-heavy boards.
   const latestElementsRef = useRef<readonly unknown[]>([]);
   const latestAppStateRef = useRef<unknown>(undefined);
-  const latestFilesRef = useRef<Record<string, unknown>>({});
 
   const handleChange = useCallback(
     (
@@ -349,12 +335,10 @@ export function BoardPage() {
       );
       latestElementsRef.current = elements;
       latestAppStateRef.current = appState;
-      latestFilesRef.current = files as Record<string, unknown>;
       scheduleSave(() => {
         const content: ExcalidrawSnapshot = {
           elements: [...latestElementsRef.current],
           appState: latestAppStateRef.current as ExcalidrawSnapshot["appState"],
-          files: latestFilesRef.current,
           yjs_update: encodeYjsState(),
         };
         latestContentRef.current = content;

--- a/apps/frontend/src/pages/board/BoardPage.tsx
+++ b/apps/frontend/src/pages/board/BoardPage.tsx
@@ -14,7 +14,7 @@ import type { ExcalidrawSnapshot } from "@/hooks/useBoardContent";
 import { useBoardInit } from "@/hooks/useBoardInit";
 import { useTheme } from "@/context/ThemeContext";
 import { apiFetch } from "@/lib/api";
-import type { ElementJson } from "@/lib/collab/yjs-bridge";
+import type { ElementJson, FileJson } from "@/lib/collab/yjs-bridge";
 import { useAuthStore } from "@/stores/authStore";
 
 type ExcalidrawAPI = Parameters<
@@ -184,9 +184,25 @@ export function BoardPage() {
     [excalidrawAPI],
   );
 
+  // Hoisted via ref so the callback can reach into useBoardCollab's
+  // return value without a forward-reference TDZ — the hook is called
+  // below and consumes onRemoteElements as one of its options.
+  const readAllFilesRef = useRef<(() => FileJson[]) | null>(null);
   const onRemoteElements = useCallback(
     (elements: ElementJson[]) => {
       if (!excalidrawAPI) return;
+      // Register every known file first. If an image element references
+      // a fileId whose blob hasn't reached this client yet, Excalidraw
+      // marks the element as not-fully-loaded and disables interaction —
+      // the peer who didn't add the image can't move it. addFiles is
+      // idempotent, so calling it on every remote elements update is
+      // safe and only meaningful when a new file actually landed.
+      const files = readAllFilesRef.current?.() ?? [];
+      if (files.length > 0) {
+        excalidrawAPI.addFiles(
+          files as unknown as Parameters<ExcalidrawAPI["addFiles"]>[0],
+        );
+      }
       excalidrawAPI.updateScene({
         elements: elements as unknown as Parameters<
           ExcalidrawAPI["updateScene"]
@@ -196,10 +212,21 @@ export function BoardPage() {
     [excalidrawAPI],
   );
 
+  const onRemoteFiles = useCallback(
+    (files: FileJson[]) => {
+      if (!excalidrawAPI || files.length === 0) return;
+      excalidrawAPI.addFiles(
+        files as unknown as Parameters<ExcalidrawAPI["addFiles"]>[0],
+      );
+    },
+    [excalidrawAPI],
+  );
+
   const {
     remoteCursors,
     sendCursor,
-    syncLocalElements,
+    syncLocalChanges,
+    readAllFiles,
     seedFromSnapshot,
     encodeYjsState,
     applyYjsState,
@@ -209,8 +236,13 @@ export function BoardPage() {
     currentUserId: user?.id ?? null,
     onRemoteDocument,
     onRemoteElements,
+    onRemoteFiles,
     onRemoteEvent: fanoutBoardEvent,
   });
+
+  useEffect(() => {
+    readAllFilesRef.current = readAllFiles;
+  }, [readAllFiles]);
 
   // Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z drive the collab-aware undo stack
   // (only undoes the local user's own ops, not remote ones).
@@ -303,23 +335,33 @@ export function BoardPage() {
   // reason the canvas felt sluggish).
   const latestElementsRef = useRef<readonly unknown[]>([]);
   const latestAppStateRef = useRef<unknown>(undefined);
+  const latestFilesRef = useRef<Record<string, unknown>>({});
 
   const handleChange = useCallback(
-    (elements: readonly unknown[], appState: unknown) => {
-      syncLocalElements(elements as readonly ElementJson[]);
+    (
+      elements: readonly unknown[],
+      appState: unknown,
+      files: Readonly<Record<string, unknown>>,
+    ) => {
+      syncLocalChanges(
+        elements as readonly ElementJson[],
+        files as Readonly<Record<string, FileJson>>,
+      );
       latestElementsRef.current = elements;
       latestAppStateRef.current = appState;
+      latestFilesRef.current = files as Record<string, unknown>;
       scheduleSave(() => {
         const content: ExcalidrawSnapshot = {
           elements: [...latestElementsRef.current],
           appState: latestAppStateRef.current as ExcalidrawSnapshot["appState"],
+          files: latestFilesRef.current,
           yjs_update: encodeYjsState(),
         };
         latestContentRef.current = content;
         return content;
       });
     },
-    [scheduleSave, syncLocalElements, encodeYjsState],
+    [scheduleSave, syncLocalChanges, encodeYjsState],
   );
 
   useEffect(() => {
@@ -347,6 +389,34 @@ export function BoardPage() {
       snapshot.appState ??
       undefined;
 
+    const seedFiles = () => {
+      // Prefer files materialized in the Y.Doc (authoritative); fall
+      // back to the legacy `files` field on the snapshot. Either way,
+      // every entry must reach Excalidraw via addFiles or image
+      // elements render as blank.
+      const fromDoc = readAllFiles();
+      if (fromDoc.length > 0) {
+        excalidrawAPI.addFiles(
+          fromDoc as unknown as Parameters<ExcalidrawAPI["addFiles"]>[0],
+        );
+        return;
+      }
+      const fromSnapshot = snapshot.files;
+      if (fromSnapshot && typeof fromSnapshot === "object") {
+        const arr = Object.values(fromSnapshot).filter(
+          (f): f is FileJson =>
+            !!f &&
+            typeof f === "object" &&
+            typeof (f as FileJson).id === "string",
+        );
+        if (arr.length > 0) {
+          excalidrawAPI.addFiles(
+            arr as unknown as Parameters<ExcalidrawAPI["addFiles"]>[0],
+          );
+        }
+      }
+    };
+
     if (snapshot.yjs_update) {
       applyYjsState(snapshot.yjs_update);
       if (appState != null) {
@@ -359,6 +429,7 @@ export function BoardPage() {
           >[0]["appState"],
         });
       }
+      seedFiles();
       initialSnapshotAppliedRef.current = true;
       return;
     }
@@ -378,9 +449,10 @@ export function BoardPage() {
       if (elements) {
         seedFromSnapshot(elements as readonly ElementJson[]);
       }
+      seedFiles();
       initialSnapshotAppliedRef.current = true;
     }
-  }, [excalidrawAPI, snapshot, seedFromSnapshot, applyYjsState]);
+  }, [excalidrawAPI, snapshot, seedFromSnapshot, applyYjsState, readAllFiles]);
 
   useEffect(() => {
     if (boardId != null) initialSnapshotAppliedRef.current = false;

--- a/apps/frontend/src/pages/board/SharedBoardPage.tsx
+++ b/apps/frontend/src/pages/board/SharedBoardPage.tsx
@@ -1,11 +1,19 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import * as Y from "yjs";
 import { Excalidraw } from "@excalidraw/excalidraw";
 import "@excalidraw/excalidraw/index.css";
 import "@/styles/excalidraw-board.css";
 
 import { PageTitle } from "@/components/PageTitle";
 import { useTheme } from "@/context/ThemeContext";
+import {
+  readElementsFromYMap,
+  readFilesFromYMap,
+  type ElementJson,
+  type FileJson,
+} from "@/lib/collab/yjs-bridge";
+import { decodeYjsUpdate } from "@/lib/collab/yjs-persistence";
 
 const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:8000";
 
@@ -45,7 +53,44 @@ type Snapshot = {
   elements?: readonly unknown[] | null;
   appState?: Record<string, unknown> | null;
   files?: Record<string, unknown> | null;
+  yjs_update?: string | null;
 };
+
+// New saves omit `files` because the same blobs are already inside
+// `yjs_update`. Decode the Y.Doc here so the read-only viewer renders
+// images regardless of whether the snapshot was written before or after
+// that change.
+function unpackSnapshot(snapshot: Snapshot): {
+  elements?: readonly unknown[];
+  files?: Record<string, unknown>;
+  appState?: Record<string, unknown>;
+} {
+  if (snapshot.yjs_update) {
+    try {
+      const doc = new Y.Doc();
+      Y.applyUpdate(doc, decodeYjsUpdate(snapshot.yjs_update));
+      const ymap = doc.getMap<ElementJson>("elements");
+      const yfiles = doc.getMap<FileJson>("files");
+      const elements = readElementsFromYMap(ymap);
+      const fileEntries = readFilesFromYMap(yfiles);
+      doc.destroy();
+      const files: Record<string, unknown> = {};
+      for (const f of fileEntries) files[f.id] = f;
+      return {
+        elements: elements.length > 0 ? elements : undefined,
+        files: fileEntries.length > 0 ? files : undefined,
+        appState: snapshot.appState ?? undefined,
+      };
+    } catch {
+      // Corrupt yjs_update — fall through to legacy fields.
+    }
+  }
+  return {
+    elements: snapshot.elements ?? undefined,
+    files: snapshot.files ?? undefined,
+    appState: snapshot.appState ?? undefined,
+  };
+}
 
 export function SharedBoardPage() {
   const { token } = useParams<{ token: string }>();
@@ -104,13 +149,14 @@ export function SharedBoardPage() {
     );
   }
 
+  const unpacked = unpackSnapshot(snapshot);
   const initialData = {
-    elements: snapshot.elements ?? undefined,
+    elements: unpacked.elements,
     appState:
-      normalizeAppStateForExcalidraw(snapshot.appState) ??
-      snapshot.appState ??
+      normalizeAppStateForExcalidraw(unpacked.appState) ??
+      unpacked.appState ??
       undefined,
-    files: snapshot.files ?? undefined,
+    files: unpacked.files,
   } as React.ComponentProps<typeof Excalidraw>["initialData"];
 
   return (

--- a/apps/frontend/src/pages/board/SharedBoardPage.tsx
+++ b/apps/frontend/src/pages/board/SharedBoardPage.tsx
@@ -44,6 +44,7 @@ const VIEWER_UI_OPTIONS = {
 type Snapshot = {
   elements?: readonly unknown[] | null;
   appState?: Record<string, unknown> | null;
+  files?: Record<string, unknown> | null;
 };
 
 export function SharedBoardPage() {
@@ -109,6 +110,7 @@ export function SharedBoardPage() {
       normalizeAppStateForExcalidraw(snapshot.appState) ??
       snapshot.appState ??
       undefined,
+    files: snapshot.files ?? undefined,
   } as React.ComponentProps<typeof Excalidraw>["initialData"];
 
   return (


### PR DESCRIPTION
This pull request implements robust support for collaborative image/file synchronization in the board editor, ensuring that image blobs (files) are reliably shared and loaded across all peers. It introduces new logic for managing files in the Yjs-based collaboration layer, updates the frontend to handle file state alongside elements, and adds comprehensive tests to prevent regression bugs related to file and element syncing.

**Collaboration and Synchronization Enhancements:**

* Added support for synchronizing files (images/blobs) via Yjs: introduced `FileJson` type, `applyFilesToYMap`, and `readFilesFromYMap` functions, and updated the collaboration hook (`useBoardCollab`) to handle file syncing, observation, and callbacks. [[1]](diffhunk://#diff-918c164f675ecf91ccacdcfb05acf31bbddfaa12c63ce8e7e25c20b1418e978fR54-R117) [[2]](diffhunk://#diff-e94e2b631d9ecca732964cb88e4dc6e9f31bc0813e8c353e5a99416b5ca698b0R9-R13) [[3]](diffhunk://#diff-e94e2b631d9ecca732964cb88e4dc6e9f31bc0813e8c353e5a99416b5ca698b0R55) [[4]](diffhunk://#diff-e94e2b631d9ecca732964cb88e4dc6e9f31bc0813e8c353e5a99416b5ca698b0R121-R174) [[5]](diffhunk://#diff-e94e2b631d9ecca732964cb88e4dc6e9f31bc0813e8c353e5a99416b5ca698b0R202-R204)
* Updated the board page to register files with Excalidraw whenever new files are received or loaded, ensuring that image elements always have their corresponding blobs and avoiding blank images or disabled interactions. [[1]](diffhunk://#diff-fa8a70aa0f7e14a27f59493641cb2a4beb04de691632e6615b265c74249f24a9L17-R17) [[2]](diffhunk://#diff-fa8a70aa0f7e14a27f59493641cb2a4beb04de691632e6615b265c74249f24a9R187-R205) [[3]](diffhunk://#diff-fa8a70aa0f7e14a27f59493641cb2a4beb04de691632e6615b265c74249f24a9R215-R229) [[4]](diffhunk://#diff-fa8a70aa0f7e14a27f59493641cb2a4beb04de691632e6615b265c74249f24a9R239-R246) [[5]](diffhunk://#diff-fa8a70aa0f7e14a27f59493641cb2a4beb04de691632e6615b265c74249f24a9R392-R419) [[6]](diffhunk://#diff-fa8a70aa0f7e14a27f59493641cb2a4beb04de691632e6615b265c74249f24a9R432) [[7]](diffhunk://#diff-fa8a70aa0f7e14a27f59493641cb2a4beb04de691632e6615b265c74249f24a9R452-R455)

**API and Data Model Updates:**

* Extended the board snapshot and shared board page data models to include a `files` field, ensuring that image data is preserved and loaded even for legacy boards. [[1]](diffhunk://#diff-77abe87bc6dfd8af71302a7c46bc251583a158d666047153c85fd40a76bb2d86R9-R11) [[2]](diffhunk://#diff-2b71fe47c13ff52c40a6a606a09698d98a23754c7bfbe630c7c2e84693dd2fafR47) [[3]](diffhunk://#diff-2b71fe47c13ff52c40a6a606a09698d98a23754c7bfbe630c7c2e84693dd2fafR113)

**Testing and Regression Prevention:**

* Added comprehensive tests for file synchronization and for suppressing "echo" updates when element changes are only superficial (e.g., only `versionNonce`, `version`, or `updated` fields change), preventing mid-drag snap-back bugs and unnecessary updates. [[1]](diffhunk://#diff-7d894af0eb9d9f037a56d22e2797127f531f5ff49a611950d9d4f6230768a8eaR5-R9) [[2]](diffhunk://#diff-7d894af0eb9d9f037a56d22e2797127f531f5ff49a611950d9d4f6230768a8eaR123-R284)

**Internal Refactoring:**

* Refactored the change handling logic in the board page to use a combined `syncLocalChanges` function, ensuring atomic updates of elements and files and preventing race conditions where an image element might reference a file not yet present. [[1]](diffhunk://#diff-fa8a70aa0f7e14a27f59493641cb2a4beb04de691632e6615b265c74249f24a9R338-R364) [[2]](diffhunk://#diff-e94e2b631d9ecca732964cb88e4dc6e9f31bc0813e8c353e5a99416b5ca698b0R121-R174) [[3]](diffhunk://#diff-e94e2b631d9ecca732964cb88e4dc6e9f31bc0813e8c353e5a99416b5ca698b0R202-R204)

These changes collectively ensure a smoother, more reliable collaborative editing experience, especially when working with images and other file-based elements.