### PR TITLE
fix(i18n): guard against out-of-order locale load resolution

### DIFF
--- a/apps/frontend/src/context/I18nContext.tsx
+++ b/apps/frontend/src/context/I18nContext.tsx
@@ -36,7 +36,11 @@ export function I18nProvider({ children }: { children: ReactNode }) {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     loadLocale(lang).then((msgs) => {
+      // Discard a stale response: if `lang` changed again before this
+      // resolved, a newer effect run already owns `messages`.
+      if (cancelled) return;
       setMessages(msgs);
       setReady(true);
       try {
@@ -45,6 +49,9 @@ export function I18nProvider({ children }: { children: ReactNode }) {
         // Ignore storage errors; i18n still works without persistence.
       }
     });
+    return () => {
+      cancelled = true;
+    };
   }, [lang]);
 
   const setLang = useCallback((lng: SupportedLang) => {


### PR DESCRIPTION
## Summary
- `I18nProvider`'s locale-loading effect had no cancellation guard. Switching languages twice quickly (e.g. en → az → ru before the first load resolves) let an older `loadLocale` promise resolve after a newer one, overwriting `messages` with the wrong language while `lang` state pointed elsewhere.
- Added a `cancelled` flag, following the same pattern already used in `useBoardInit.ts` elsewhere in this codebase — the stale response is discarded instead of applied.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test` — 24/24 passing (no dedicated I18nContext test exists yet; there's no `@testing-library/react` in this project yet, so I verified behavior manually rather than adding new test infra for one hook)
- [x] `npm run build` — succeeds
- [x] Booted the dev server and confirmed the app loads normally with the change

Fixes #31