### PR TITLE
fix(ws): broadcast peer.left so remote cursors disappear immediately

### DIFF
--- a/api/app/app/websocket/manager.py
+++ b/api/app/app/websocket/manager.py
@@ -15,6 +15,10 @@ FRAME_BINARY = b"B"
 ACTIVE_CONNECTIONS: dict[str, list[WebSocket]] = {}
 _listeners: dict[str, asyncio.Task[Any]] = {}
 
+# Last-seen cursor identity per connection, so we can tell peers exactly
+# who left when the socket closes (same key shape as a cursor.moved frame).
+_CONNECTION_CURSOR_IDENTITY: dict[WebSocket, dict[str, str]] = {}
+
 
 async def _get_redis_binary() -> Redis:
     # decode_responses=False so binary Yjs frames survive the round-trip.
@@ -28,7 +32,17 @@ async def subscribe_board(websocket: WebSocket, board_id: str) -> None:
     ACTIVE_CONNECTIONS[board_id].append(websocket)
 
 
-def unsubscribe_board(websocket: WebSocket, board_id: str) -> None:
+def note_cursor_identity(websocket: WebSocket, client_id: str, user_id: str) -> None:
+    """Remember the client_id/user_id a connection last broadcast a cursor as,
+    so unsubscribe_board can tell peers exactly who left."""
+    _CONNECTION_CURSOR_IDENTITY[websocket] = {
+        "client_id": client_id,
+        "user_id": user_id,
+    }
+
+
+async def unsubscribe_board(websocket: WebSocket, board_id: str) -> None:
+    identity = _CONNECTION_CURSOR_IDENTITY.pop(websocket, None)
     if board_id in ACTIVE_CONNECTIONS:
         ACTIVE_CONNECTIONS[board_id] = [
             ws for ws in ACTIVE_CONNECTIONS[board_id] if ws != websocket
@@ -38,6 +52,14 @@ def unsubscribe_board(websocket: WebSocket, board_id: str) -> None:
             if board_id in _listeners:
                 _listeners[board_id].cancel()
                 del _listeners[board_id]
+
+    if identity is not None:
+        # Best-effort: if Redis/publish fails here, the frontend's
+        # timeout-based sweep still cleans up the stale cursor eventually.
+        try:
+            await broadcast_to_board(board_id, "peer.left", identity)
+        except Exception:
+            pass
 
 
 async def broadcast_to_board(board_id: str, event: str, payload: dict[str, Any]) -> None:

--- a/api/app/app/websocket/router.py
+++ b/api/app/app/websocket/router.py
@@ -14,6 +14,7 @@ from app.modules.workspaces.repository import is_member as workspace_is_member
 from app.websocket.manager import (
     broadcast_binary_to_board,
     broadcast_to_board,
+    note_cursor_identity,
     subscribe_board,
     unsubscribe_board,
 )
@@ -90,7 +91,9 @@ async def _authenticate(websocket: WebSocket, board_id: str) -> User | None:
     return user
 
 
-async def _handle_text_frame(raw: str, board_id: str, user: User) -> None:
+async def _handle_text_frame(
+    raw: str, board_id: str, user: User, websocket: WebSocket
+) -> None:
     try:
         msg = json.loads(raw)
     except json.JSONDecodeError:
@@ -104,6 +107,9 @@ async def _handle_text_frame(raw: str, board_id: str, user: User) -> None:
     if event == "cursor.moved":
         payload["user_id"] = str(user.id)
         payload["username"] = user.username or user.email or "Anonymous"
+        client_id = payload.get("client_id")
+        if isinstance(client_id, str) and client_id:
+            note_cursor_identity(websocket, client_id, str(user.id))
     await broadcast_to_board(board_id, event, payload)
 
 
@@ -131,7 +137,7 @@ async def board_websocket(websocket: WebSocket, board_id: str) -> None:
                 if len(text.encode("utf-8", errors="ignore")) > MAX_TEXT_FRAME_BYTES:
                     await websocket.close(code=CLOSE_PAYLOAD_TOO_LARGE)
                     break
-                await _handle_text_frame(text, board_id, user)
+                await _handle_text_frame(text, board_id, user, websocket)
             elif (data := frame.get("bytes")) is not None:
                 if len(data) > MAX_BINARY_FRAME_BYTES:
                     await websocket.close(code=CLOSE_PAYLOAD_TOO_LARGE)
@@ -142,4 +148,4 @@ async def board_websocket(websocket: WebSocket, board_id: str) -> None:
     except Exception as exc:
         logger.warning("WebSocket board %s error: %s", board_id, exc)
     finally:
-        unsubscribe_board(websocket, board_id)
+        await unsubscribe_board(websocket, board_id)

--- a/apps/frontend/src/hooks/useBoardWebSocket.ts
+++ b/apps/frontend/src/hooks/useBoardWebSocket.ts
@@ -139,6 +139,22 @@ export function useBoardWebSocket(
         }
       }
 
+      if (eventType === "peer.left") {
+        const leftClientId =
+          typeof data.client_id === "string" ? data.client_id : null;
+        const leftUserId =
+          typeof data.user_id === "string" ? data.user_id : null;
+        const key = leftClientId || leftUserId;
+        if (key) {
+          setRemoteCursors((prev) => {
+            if (!(key in prev)) return prev;
+            const next = { ...prev };
+            delete next[key];
+            return next;
+          });
+        }
+      }
+
       if (
         eventType === "element.updated" &&
         (data as { type?: string }).type === "excalidraw_snapshot" &&


### PR DESCRIPTION
## Summary
- Remote cursors were previously only pruned by a 15s client-side timeout sweep, so a collaborator who disconnects appears to "freeze" in place for up to 15 seconds.
- The WebSocket manager now remembers the `client_id`/`user_id` a connection last broadcast a cursor as (captured from `cursor.moved` frames), and emits a `peer.left` event to the board's channel when that connection is torn down in `unsubscribe_board`.
- The frontend (`useBoardWebSocket.ts`) now handles `peer.left` by immediately deleting that entry from `remoteCursors`, keyed the same way `cursor.moved` keys it (client_id, falling back to user_id).
- The existing timeout-based sweep is left in place as a fallback for cases where the disconnect event itself doesn't arrive (e.g. abrupt network loss on the receiving end).

## Verification
- `ruff check .`, `mypy .`, `pytest` — all clean (37/37 backend tests passing).
- `npm run lint` — clean.
- End-to-end against a local `docker-compose` stack (fresh Postgres volume + Redis) with the real API running via `uvicorn`: created a test user/workspace/board, opened two real WebSocket connections (client A and B), had A send a `cursor.moved`, confirmed B received it, then closed A's socket and confirmed B received `peer.left` with the exact `client_id` A had been using — matches the key `remoteCursors` uses, so the frontend correctly drops that entry immediately rather than waiting for the timeout.

Fixes #35