### PR TITLE
fix(api): retry token refresh on network failure instead of treating it like a dead session

### DIFF
--- a/apps/frontend/src/lib/api.test.ts
+++ b/apps/frontend/src/lib/api.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { apiFetch } from "@/lib/api";
+import { useAuthStore } from "@/stores/authStore";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+describe("apiFetch refresh error handling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useAuthStore.setState({
+      token: "old-access-token",
+      refreshToken: "refresh-token-1",
+      user: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("does not clear auth state when the refresh call fails at the network level", async () => {
+    const fetchMock = vi
+      .fn()
+      // original request -> 401
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      // refresh attempt 1 -> network failure
+      .mockRejectedValueOnce(new TypeError("network error"))
+      // refresh attempt 2 (retry) -> network failure again
+      .mockRejectedValueOnce(new TypeError("network error"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resultPromise = apiFetch("/api/boards");
+    // Let the internal retry's setTimeout fire.
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.status).toBe(401);
+    // A network-level failure during refresh must NOT be treated as a
+    // confirmed-dead session: auth state should be untouched.
+    expect(useAuthStore.getState().refreshToken).toBe("refresh-token-1");
+    expect(useAuthStore.getState().token).toBe("old-access-token");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("clears auth state when the refresh endpoint explicitly rejects the refresh token", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await apiFetch("/api/boards");
+
+    expect(result.status).toBe(401);
+    expect(useAuthStore.getState().refreshToken).toBeNull();
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  it("retries the refresh once and succeeds if the second attempt reaches the server", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockRejectedValueOnce(new TypeError("network error"))
+      .mockResolvedValueOnce(
+        jsonResponse({ access_token: "new-token", refresh_token: "refresh-token-2" }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resultPromise = apiFetch("/api/boards");
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.status).toBe(200);
+    expect(useAuthStore.getState().token).toBe("new-token");
+    expect(useAuthStore.getState().refreshToken).toBe("refresh-token-2");
+  });
+});

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -53,43 +53,66 @@ function buildHeaders(
 // so parallel calls would invalidate each other.
 let refreshInFlight: Promise<string | null> | null = null;
 
+const REFRESH_NETWORK_RETRY_DELAY_MS = 500;
+
 async function refreshAccessToken(): Promise<string | null> {
   if (refreshInFlight) return refreshInFlight;
 
   const run = async (): Promise<string | null> => {
     const refreshToken = useAuthStore.getState().refreshToken;
     if (!refreshToken) return null;
-    try {
-      const res = await fetch(`${API_BASE}/api/auth/refresh`, {
+
+    const attemptRefresh = () =>
+      fetch(`${API_BASE}/api/auth/refresh`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refresh_token: refreshToken }),
       });
-      if (!res.ok) {
-        useAuthStore.getState().logout();
-        return null;
-      }
-      const data: {
-        access_token?: string;
-        refresh_token?: string | null;
-      } = await res.json();
-      if (!data.access_token) {
-        useAuthStore.getState().logout();
-        return null;
-      }
-      useAuthStore.getState().setTokens({
-        token: data.access_token,
-        refreshToken: data.refresh_token ?? null,
-      });
-      return data.access_token;
+
+    let res: Response;
+    try {
+      res = await attemptRefresh();
     } catch {
-      return null;
-    } finally {
-      refreshInFlight = null;
+      // A thrown fetch error here is a network-level failure (offline,
+      // DNS, server unreachable) -- distinct from a confirmed-invalid
+      // session (explicit non-2xx below). Retry once after a short delay:
+      // most real-world blips are transient, and treating this the same
+      // as an explicit 401 would log the user out over a flaky connection.
+      await new Promise((r) => setTimeout(r, REFRESH_NETWORK_RETRY_DELAY_MS));
+      try {
+        res = await attemptRefresh();
+      } catch {
+        // Still a network-level failure: leave auth state untouched. We
+        // deliberately do NOT call logout() here -- the session hasn't
+        // been confirmed invalid, only unreachable.
+        return null;
+      }
     }
+
+    if (!res.ok) {
+      // A real response from the server saying the refresh token itself
+      // is invalid/expired -- this is a confirmed-dead session.
+      useAuthStore.getState().logout();
+      return null;
+    }
+    const data: {
+      access_token?: string;
+      refresh_token?: string | null;
+    } = await res.json();
+    if (!data.access_token) {
+      useAuthStore.getState().logout();
+      return null;
+    }
+    useAuthStore.getState().setTokens({
+      token: data.access_token,
+      refreshToken: data.refresh_token ?? null,
+    });
+    return data.access_token;
   };
 
-  refreshInFlight = run();
+  refreshInFlight = run().finally(() => {
+    refreshInFlight = null;
+  });
   return refreshInFlight;
 }
 


### PR DESCRIPTION
## Summary
- `refreshAccessToken()` treated an explicit non-2xx response from `/api/auth/refresh` (logout) and a thrown network error (silently return null, no logout) inconsistently, but `apiFetch` surfaced the original request's 401 to the caller in both cases either way. So a transient network blip during refresh produced the same "looks logged out" UI as a genuinely dead session, while `authStore` quietly kept the old (not actually confirmed-invalid) tokens — inconsistent state that could show as a confusing logged-out flash that resolves itself on retry.
- Fix: a network-level failure now retries the refresh once after a short delay before giving up (most real blips are transient). Only a confirmed non-2xx response from the server — a real "this refresh token is invalid" — triggers `logout()`.

## Test plan
- [x] Added `apps/frontend/src/lib/api.test.ts` (new — no prior test file existed for this module):
  - network failure on both refresh attempts → no `logout()`, tokens preserved
  - explicit 401 from refresh endpoint → `logout()` called, tokens cleared
  - network failure then a successful retry → new tokens applied, request proceeds
- [x] `npm run test` — 27/27 passing
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds

Fixes #33