### PR TITLE
fix(board): reset all per-board caches on board switch, not just one flag

### DIFF
--- a/apps/frontend/src/pages/board/BoardPage.tsx
+++ b/apps/frontend/src/pages/board/BoardPage.tsx
@@ -439,7 +439,15 @@ export function BoardPage() {
   }, [excalidrawAPI, snapshot, seedFromSnapshot, applyYjsState, readAllFiles]);
 
   useEffect(() => {
-    if (boardId != null) initialSnapshotAppliedRef.current = false;
+    if (boardId == null) return;
+    // All per-board caches, not just the snapshot-applied flag: without
+    // this, switching boards then closing the tab before the new board's
+    // first onChange fires would save the *previous* board's cached
+    // content under the *new* board's id via the beforeunload handler.
+    initialSnapshotAppliedRef.current = false;
+    latestContentRef.current = null;
+    latestElementsRef.current = [];
+    latestAppStateRef.current = undefined;
   }, [boardId]);
 
   if (!authChecked || !boardId) {


### PR DESCRIPTION
## Summary
- `BoardPage.tsx`'s board-switch effect only reset `initialSnapshotAppliedRef`. `latestContentRef`, `latestElementsRef`, and `latestAppStateRef` (used by the debounced-save getter and the `beforeunload` handler) kept whatever the *previous* board's last `onChange` produced until the new board emitted its own first change.
- Since `beforeunload` reads `latestContentRef.current` directly and saves it against the *current* `boardId`, switching boards and closing the tab before making any edit on the new board could silently save the old board's content under the new board's id.
- Fix: reset all four per-board refs together whenever `boardId` changes. `latestContentRef.current = null` also means the existing `beforeunload` guard (`content?.elements?.length || content?.appState || content?.yjs_update`) naturally no-ops until a real change happens on the new board — no separate guard needed.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test` — 24/24 passing
- [x] `npm run build` — succeeds

Fixes #32