### PR TITLE
fix(ws): reconnect with backoff after a dropped board WebSocket

### DIFF
--- a/apps/frontend/src/hooks/useBoardWebSocket.ts
+++ b/apps/frontend/src/hooks/useBoardWebSocket.ts
@@ -3,6 +3,8 @@ import { getBoardWsUrl } from "@/lib/api";
 
 const CURSOR_EXPIRE_MS = 15_000;
 const CURSOR_SEND_THROTTLE_MS = 50;
+const RECONNECT_BASE_DELAY_MS = 1_000;
+const RECONNECT_MAX_DELAY_MS = 10_000;
 
 export interface RemoteCursor {
   x: number;
@@ -38,6 +40,10 @@ export function useBoardWebSocket(
 ) {
   const { onRemoteDocument, onRemoteBinary, onRemoteEvent } = options;
   const [connected, setConnected] = useState(false);
+  // True while a dropped connection is being retried in the background —
+  // lets the UI show "reconnecting" instead of silently doing nothing
+  // until the user notices collaboration stopped working.
+  const [reconnecting, setReconnecting] = useState(false);
   const [remoteCursors, setRemoteCursors] = useState<
     Record<string, RemoteCursor>
   >({});
@@ -80,101 +86,131 @@ export function useBoardWebSocket(
   useEffect(() => {
     if (!boardId || !token) return;
 
-    const url = getBoardWsUrl(boardId);
-    const ws = new WebSocket(url);
-    ws.binaryType = "arraybuffer";
-    wsRef.current = ws;
+    // Guards against reconnecting after this effect has been cleaned up
+    // (boardId/token changed, or the component unmounted) — closing the
+    // socket in cleanup would otherwise trigger onclose -> reconnect.
+    let torndown = false;
+    let reconnectAttempt = 0;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
-    ws.onopen = () => {
-      try {
-        ws.send(JSON.stringify({ type: "auth", token }));
-      } catch {
-        // already closed
-      }
-    };
+    const connect = () => {
+      const url = getBoardWsUrl(boardId);
+      const ws = new WebSocket(url);
+      ws.binaryType = "arraybuffer";
+      wsRef.current = ws;
 
-    ws.onclose = () => setConnected(false);
-    ws.onerror = () => setConnected(false);
-
-    ws.onmessage = (event) => {
-      if (event.data instanceof ArrayBuffer) {
-        onRemoteBinaryRef.current?.(new Uint8Array(event.data));
-        return;
-      }
-      if (typeof event.data !== "string") return;
-
-      let msg: { event?: string; data?: Record<string, unknown> };
-      try {
-        msg = JSON.parse(event.data) as typeof msg;
-      } catch {
-        return;
-      }
-      const eventType = msg.event;
-      const data = msg.data ?? {};
-
-      if (eventType === "auth.ok") {
-        setConnected(true);
-        return;
-      }
-
-      if (eventType === "cursor.moved") {
-        const senderClientId =
-          typeof data.client_id === "string" ? data.client_id : null;
-        // Self-echo only: drop our own frames. Same user in another
-        // tab has a different client_id and SHOULD still render.
-        if (senderClientId && senderClientId === clientId) return;
-        const userId = data.user_id as string | undefined;
-        const x = typeof data.x === "number" ? data.x : 0;
-        const y = typeof data.y === "number" ? data.y : 0;
-        const username =
-          typeof data.username === "string" ? data.username : "Anonymous";
-        // Key by client_id when present so two tabs of the same
-        // account don't clobber each other.
-        const key = senderClientId || userId;
-        if (key) {
-          setRemoteCursors((prev) => ({
-            ...prev,
-            [key]: { x, y, username, lastSeen: Date.now() },
-          }));
+      ws.onopen = () => {
+        try {
+          ws.send(JSON.stringify({ type: "auth", token }));
+        } catch {
+          // already closed
         }
-      }
+      };
 
-      if (eventType === "peer.left") {
-        const leftClientId =
-          typeof data.client_id === "string" ? data.client_id : null;
-        const leftUserId =
-          typeof data.user_id === "string" ? data.user_id : null;
-        const key = leftClientId || leftUserId;
-        if (key) {
-          setRemoteCursors((prev) => {
-            if (!(key in prev)) return prev;
-            const next = { ...prev };
-            delete next[key];
-            return next;
-          });
-        }
-      }
-
-      if (
-        eventType === "element.updated" &&
-        (data as { type?: string }).type === "excalidraw_snapshot" &&
-        ((data as { elements?: unknown }).elements != null ||
-          (data as { appState?: unknown }).appState != null)
-      ) {
-        onRemoteDocumentRef.current?.(
-          data as { elements?: unknown[]; appState?: unknown },
+      ws.onclose = () => {
+        setConnected(false);
+        if (torndown) return;
+        setReconnecting(true);
+        const delay = Math.min(
+          RECONNECT_BASE_DELAY_MS * 2 ** reconnectAttempt,
+          RECONNECT_MAX_DELAY_MS,
         );
-      }
+        reconnectAttempt += 1;
+        reconnectTimer = setTimeout(() => {
+          if (!torndown) connect();
+        }, delay);
+      };
+      // A real close always follows an error per the WebSocket spec, so
+      // onclose alone owns reconnect scheduling — this only updates state.
+      ws.onerror = () => setConnected(false);
 
-      if (eventType && eventType !== "auth.ok") {
-        onRemoteEventRef.current?.(eventType, data);
-      }
+      ws.onmessage = (event) => {
+        if (event.data instanceof ArrayBuffer) {
+          onRemoteBinaryRef.current?.(new Uint8Array(event.data));
+          return;
+        }
+        if (typeof event.data !== "string") return;
+
+        let msg: { event?: string; data?: Record<string, unknown> };
+        try {
+          msg = JSON.parse(event.data) as typeof msg;
+        } catch {
+          return;
+        }
+        const eventType = msg.event;
+        const data = msg.data ?? {};
+
+        if (eventType === "auth.ok") {
+          setConnected(true);
+          setReconnecting(false);
+          reconnectAttempt = 0;
+          return;
+        }
+
+        if (eventType === "cursor.moved") {
+          const senderClientId =
+            typeof data.client_id === "string" ? data.client_id : null;
+          // Self-echo only: drop our own frames. Same user in another
+          // tab has a different client_id and SHOULD still render.
+          if (senderClientId && senderClientId === clientId) return;
+          const userId = data.user_id as string | undefined;
+          const x = typeof data.x === "number" ? data.x : 0;
+          const y = typeof data.y === "number" ? data.y : 0;
+          const username =
+            typeof data.username === "string" ? data.username : "Anonymous";
+          // Key by client_id when present so two tabs of the same
+          // account don't clobber each other.
+          const key = senderClientId || userId;
+          if (key) {
+            setRemoteCursors((prev) => ({
+              ...prev,
+              [key]: { x, y, username, lastSeen: Date.now() },
+            }));
+          }
+        }
+
+        if (eventType === "peer.left") {
+          const leftClientId =
+            typeof data.client_id === "string" ? data.client_id : null;
+          const leftUserId =
+            typeof data.user_id === "string" ? data.user_id : null;
+          const key = leftClientId || leftUserId;
+          if (key) {
+            setRemoteCursors((prev) => {
+              if (!(key in prev)) return prev;
+              const next = { ...prev };
+              delete next[key];
+              return next;
+            });
+          }
+        }
+
+        if (
+          eventType === "element.updated" &&
+          (data as { type?: string }).type === "excalidraw_snapshot" &&
+          ((data as { elements?: unknown }).elements != null ||
+            (data as { appState?: unknown }).appState != null)
+        ) {
+          onRemoteDocumentRef.current?.(
+            data as { elements?: unknown[]; appState?: unknown },
+          );
+        }
+
+        if (eventType && eventType !== "auth.ok") {
+          onRemoteEventRef.current?.(eventType, data);
+        }
+      };
     };
+
+    connect();
 
     return () => {
-      ws.close();
+      torndown = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      wsRef.current?.close();
       wsRef.current = null;
       setConnected(false);
+      setReconnecting(false);
       setRemoteCursors({});
     };
   }, [boardId, token, clientId]);
@@ -202,5 +238,5 @@ export function useBoardWebSocket(
     ws.send(data);
   }, []);
 
-  return { connected, remoteCursors, sendCursor, sendBinary };
+  return { connected, reconnecting, remoteCursors, sendCursor, sendBinary };
 }

--- a/apps/frontend/src/pages/board/BoardPage.tsx
+++ b/apps/frontend/src/pages/board/BoardPage.tsx
@@ -211,6 +211,7 @@ export function BoardPage() {
   );
 
   const {
+    reconnecting,
     remoteCursors,
     sendCursor,
     syncLocalChanges,
@@ -509,6 +510,11 @@ export function BoardPage() {
       )}
       <div className="flex-1 min-h-0 flex">
         <div className="flex-1 min-h-0 relative" ref={containerRef}>
+          {reconnecting && (
+            <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 rounded-full bg-[var(--bg-secondary)] border border-[var(--border)] px-3 py-1 text-xs text-[var(--text-secondary)] shadow-sm">
+              Reconnecting…
+            </div>
+          )}
           {contentLoading ? (
             <div className="h-full flex items-center justify-center">
               <div className="text-[var(--text-muted)]">Loading canvas...</div>


### PR DESCRIPTION
## Summary
- `useBoardWebSocket`'s `ws.onclose`/`ws.onerror` only set `connected = false` with no retry — a transient network blip or server restart permanently killed real-time collaboration for the rest of the session, with no visible indication anything was wrong, until the user manually reloaded.
- Now the hook retries with exponential backoff (1s base, capped at 10s) whenever the socket drops unexpectedly (not on intentional teardown from unmount/boardId/token change), and exposes a `reconnecting` flag.
- `BoardPage` shows a small floating "Reconnecting…" pill over the canvas while `reconnecting` is true.
- On successful reconnect (`auth.ok`), `useBoardCollab`'s existing effect (unchanged) still re-sends the full Yjs doc state, so no local edits made while disconnected are lost.

## Test plan
- [x] `npm run lint` / `npm run test` (24/24) / `npm run build` — all clean
- [x] End-to-end with Playwright against a live dev server + API: loaded a real board, killed the API process to force the WebSocket closed, confirmed the "Reconnecting…" banner appeared immediately; restarted the API and confirmed the banner disappeared on its own (successful auto-reconnect) with no manual reload

Fixes #30