### PR TITLE
fix(ws): don't return from subscribe_board until Redis is actually subscribed

### DIFF
--- a/api/app/app/websocket/manager.py
+++ b/api/app/app/websocket/manager.py
@@ -15,6 +15,12 @@ FRAME_BINARY = b"B"
 ACTIVE_CONNECTIONS: dict[str, list[WebSocket]] = {}
 _listeners: dict[str, asyncio.Task[Any]] = {}
 
+# Signaled once a board's redis_listener has actually completed
+# `pubsub.subscribe(...)`. subscribe_board awaits this before returning
+# so a publish immediately after the first connection can't be dropped
+# by the pubsub not being subscribed to the channel yet.
+_listener_ready: dict[str, asyncio.Event] = {}
+
 # Last-seen cursor identity per connection, so we can tell peers exactly
 # who left when the socket closes (same key shape as a cursor.moved frame).
 _CONNECTION_CURSOR_IDENTITY: dict[WebSocket, dict[str, str]] = {}
@@ -28,7 +34,34 @@ async def _get_redis_binary() -> Redis:
 async def subscribe_board(websocket: WebSocket, board_id: str) -> None:
     if board_id not in ACTIVE_CONNECTIONS:
         ACTIVE_CONNECTIONS[board_id] = []
-        _listeners[board_id] = asyncio.create_task(redis_listener(board_id))
+        ready = asyncio.Event()
+        _listener_ready[board_id] = ready
+        task = asyncio.create_task(redis_listener(board_id, ready))
+        _listeners[board_id] = task
+
+        # Don't return (and let the caller start relaying messages) until
+        # the listener has actually subscribed to the Redis channel --
+        # otherwise a publish in this window is silently dropped for
+        # every subscriber on this board, not just this new connection.
+        # Race against the listener task itself so a Redis failure at
+        # connect time surfaces immediately instead of hanging forever.
+        ready_wait = asyncio.ensure_future(ready.wait())
+        try:
+            await asyncio.wait(
+                {ready_wait, task}, return_when=asyncio.FIRST_COMPLETED
+            )
+        finally:
+            if not ready_wait.done():
+                ready_wait.cancel()
+
+        if not ready.is_set():
+            del ACTIVE_CONNECTIONS[board_id]
+            _listeners.pop(board_id, None)
+            _listener_ready.pop(board_id, None)
+            exc = task.exception() if task.done() else None
+            raise exc if exc is not None else RuntimeError(
+                f"redis_listener for board {board_id} exited before subscribing"
+            )
     ACTIVE_CONNECTIONS[board_id].append(websocket)
 
 
@@ -52,6 +85,7 @@ async def unsubscribe_board(websocket: WebSocket, board_id: str) -> None:
             if board_id in _listeners:
                 _listeners[board_id].cancel()
                 del _listeners[board_id]
+            _listener_ready.pop(board_id, None)
 
     if identity is not None:
         # Best-effort: if Redis/publish fails here, the frontend's
@@ -77,11 +111,13 @@ async def broadcast_binary_to_board(board_id: str, data: bytes) -> None:
     await redis.aclose()
 
 
-async def redis_listener(board_id: str) -> None:
+async def redis_listener(board_id: str, ready: asyncio.Event | None = None) -> None:
     redis = await _get_redis_binary()
     pubsub = redis.pubsub()
     channel = f"{BOARD_CHANNEL_PREFIX}{board_id}".encode()
     await pubsub.subscribe(channel)
+    if ready is not None:
+        ready.set()
 
     try:
         async for message in pubsub.listen():

--- a/api/app/app/websocket/router.py
+++ b/api/app/app/websocket/router.py
@@ -126,7 +126,12 @@ async def board_websocket(websocket: WebSocket, board_id: str) -> None:
     except Exception:
         return
 
-    await subscribe_board(websocket, board_id)
+    try:
+        await subscribe_board(websocket, board_id)
+    except Exception as exc:
+        logger.warning("WebSocket board %s subscribe failed: %s", board_id, exc)
+        await websocket.close(code=CLOSE_INTERNAL_ERROR)
+        return
 
     try:
         while True:

--- a/api/app/tests/test_ws_manager_subscribe_race.py
+++ b/api/app/tests/test_ws_manager_subscribe_race.py
@@ -1,0 +1,115 @@
+"""subscribe_board must not return until the Redis pubsub subscription for
+the board is actually active, and must not hang forever if Redis itself
+is unreachable at connect time.
+
+These use a fake Redis/pubsub (no real Redis needed) so the timing
+assertions are deterministic instead of relying on a real network race.
+"""
+
+import asyncio
+import time
+from typing import Any, cast
+
+import pytest
+from fastapi import WebSocket
+
+from app.websocket import manager
+
+
+class FakePubSub:
+    def __init__(self, subscribe_delay: float = 0.0, fail: bool = False) -> None:
+        self._subscribe_delay = subscribe_delay
+        self._fail = fail
+        self.subscribed_at: float | None = None
+
+    async def subscribe(self, _channel: bytes) -> None:
+        if self._subscribe_delay:
+            await asyncio.sleep(self._subscribe_delay)
+        if self._fail:
+            raise ConnectionError("redis unreachable")
+        self.subscribed_at = time.monotonic()
+
+    async def listen(self) -> Any:
+        # Never yields -- this test only cares about subscribe() timing,
+        # not message delivery.
+        while True:
+            await asyncio.sleep(3600)
+            yield {}
+
+    async def unsubscribe(self, _channel: bytes) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+
+class FakeRedis:
+    def __init__(self, pubsub: FakePubSub) -> None:
+        self._pubsub = pubsub
+
+    def pubsub(self) -> FakePubSub:
+        return self._pubsub
+
+    async def aclose(self) -> None:
+        pass
+
+    async def publish(self, _channel: str, _data: bytes) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_manager_state() -> Any:
+    manager.ACTIVE_CONNECTIONS.clear()
+    manager._listeners.clear()
+    manager._listener_ready.clear()
+    yield
+    for task in manager._listeners.values():
+        task.cancel()
+    manager.ACTIVE_CONNECTIONS.clear()
+    manager._listeners.clear()
+    manager._listener_ready.clear()
+
+
+def test_subscribe_board_waits_for_redis_subscription(monkeypatch: Any) -> None:
+    fake_pubsub = FakePubSub(subscribe_delay=0.05)
+    fake_redis = FakeRedis(fake_pubsub)
+
+    async def fake_get_redis_binary() -> FakeRedis:
+        return fake_redis
+
+    monkeypatch.setattr(manager, "_get_redis_binary", fake_get_redis_binary)
+
+    async def run() -> None:
+        ws = cast(WebSocket, object())
+        await manager.subscribe_board(ws, "board-a")
+        returned_at = time.monotonic()
+        assert fake_pubsub.subscribed_at is not None
+        assert returned_at >= fake_pubsub.subscribed_at
+        assert ws in manager.ACTIVE_CONNECTIONS["board-a"]
+
+    asyncio.run(run())
+
+
+def test_subscribe_board_raises_instead_of_hanging_when_redis_fails(
+    monkeypatch: Any,
+) -> None:
+    fake_pubsub = FakePubSub(fail=True)
+    fake_redis = FakeRedis(fake_pubsub)
+
+    async def fake_get_redis_binary() -> FakeRedis:
+        return fake_redis
+
+    monkeypatch.setattr(manager, "_get_redis_binary", fake_get_redis_binary)
+
+    async def run() -> None:
+        ws = cast(WebSocket, object())
+        with pytest.raises(ConnectionError):
+            await asyncio.wait_for(
+                manager.subscribe_board(ws, "board-b"), timeout=2
+            )
+        # No leftover state for a board whose subscribe never succeeded.
+        assert "board-b" not in manager.ACTIVE_CONNECTIONS
+        assert "board-b" not in manager._listeners
+        assert "board-b" not in manager._listener_ready
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- `subscribe_board` scheduled `redis_listener` as a background task via `asyncio.create_task` and returned immediately, before that task's `await pubsub.subscribe(channel)` had necessarily run. A message published to the board's Redis channel in that window is silently dropped for every subscriber on the board (Redis pub/sub doesn't buffer for late subscribers) -- most likely to bite the first two users joining a fresh board at nearly the same moment.
- `subscribe_board` now awaits a readiness signal (`asyncio.Event`) set right after the listener actually subscribes, so no caller can start relaying messages until the subscription is live.
- Race the readiness wait against the listener task itself (`asyncio.wait(..., FIRST_COMPLETED)`) so a Redis failure at connect time surfaces immediately (closes the socket with `4011`) instead of hanging the connection forever if Redis is unreachable.

## Test plan
- [x] Added `api/app/tests/test_ws_manager_subscribe_race.py` with a fake Redis/pubsub (no real Redis needed) to deterministically verify:
  - `subscribe_board` never returns before the fake `subscribe()` call completes (even with an artificial delay)
  - a failing `subscribe()` raises instead of hanging, with no leftover `ACTIVE_CONNECTIONS`/`_listeners`/`_listener_ready` state for that board
- [x] `ruff check .`, `mypy .`, `pytest` — all clean (39/39 backend tests passing)
- [x] End-to-end against a live `docker-compose` stack + real Redis: two real WebSocket clients, confirmed `cursor.moved` and `peer.left` still deliver correctly after this change

Fixes #29