### PR TITLE
fix(elements): atomic upsert for board snapshots, no more duplicate rows

### DIFF
--- a/api/app/alembic/versions/00425b753873_unique_snapshot_per_board.py
+++ b/api/app/alembic/versions/00425b753873_unique_snapshot_per_board.py
@@ -1,0 +1,57 @@
+"""unique snapshot per board
+
+Revision ID: 00425b753873
+Revises: fe24635bcc34
+Create Date: 2026-07-10 12:29:54.664126
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '00425b753873'
+down_revision: Union[str, Sequence[str], None] = 'fe24635bcc34'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+SNAPSHOT_TYPE = "excalidraw_snapshot"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Before enforcing uniqueness, collapse any duplicate snapshot rows a
+    # board may already have accumulated (the bug this migration fixes):
+    # keep the most-recently-updated one per board, drop the rest.
+    op.execute(
+        f"""
+        DELETE FROM elements
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT id,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY board_id
+                           ORDER BY updated_at DESC, id DESC
+                       ) AS rn
+                FROM elements
+                WHERE type = '{SNAPSHOT_TYPE}'
+            ) ranked
+            WHERE rn > 1
+        )
+        """
+    )
+    op.create_index(
+        "ix_elements_board_snapshot_singleton",
+        "elements",
+        ["board_id"],
+        unique=True,
+        postgresql_where=sa.text(f"type = '{SNAPSHOT_TYPE}'"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_elements_board_snapshot_singleton", table_name="elements")

--- a/api/app/app/modules/elements/model.py
+++ b/api/app/app/modules/elements/model.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
 
 ElementData = dict[str, Any]
 
+# Singleton element type: a board has at most one of these, enforced by
+# a partial unique index (see alembic revision 00425b753873).
+SNAPSHOT_ELEMENT_TYPE = "excalidraw_snapshot"
+
 
 class Element(Base):
     __tablename__ = "elements"

--- a/api/app/app/modules/elements/repository.py
+++ b/api/app/app/modules/elements/repository.py
@@ -2,9 +2,10 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
-from app.modules.elements.model import Element, ElementData
+from app.modules.elements.model import SNAPSHOT_ELEMENT_TYPE, Element, ElementData
 
 
 def get_by_id(db: Session, element_id: UUID) -> Element | None:
@@ -34,6 +35,30 @@ def update(db: Session, element: Element, *, data: ElementData | None = None) ->
         element.data = {**element.data, **data}
     db.commit()
     db.refresh(element)
+    return element
+
+
+def upsert_snapshot(db: Session, *, board_id: UUID, data: ElementData) -> Element:
+    """Atomic insert-or-update of the one excalidraw_snapshot row for a
+    board, relying on the partial unique index on (board_id) WHERE
+    type = 'excalidraw_snapshot'. Replaces the old GET-list-then-decide
+    POST/PATCH dance, which raced under concurrent saves and could create
+    duplicate snapshot rows."""
+    stmt = pg_insert(Element).values(
+        board_id=board_id, type=SNAPSHOT_ELEMENT_TYPE, data=data
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=[Element.board_id],
+        index_where=(Element.type == SNAPSHOT_ELEMENT_TYPE),
+        set_={"data": stmt.excluded.data, "updated_at": func.now()},
+    )
+    db.execute(stmt)
+    db.commit()
+    element = (
+        db.query(Element)
+        .filter(Element.board_id == board_id, Element.type == SNAPSHOT_ELEMENT_TYPE)
+        .one()
+    )
     return element
 
 

--- a/api/app/app/modules/elements/router.py
+++ b/api/app/app/modules/elements/router.py
@@ -12,6 +12,7 @@ from app.modules.elements.schemas import (
     ElementListResponse,
     ElementResponse,
     ElementUpdate,
+    SnapshotUpsert,
 )
 from app.modules.elements.service import (
     bulk_update_elements,
@@ -20,6 +21,7 @@ from app.modules.elements.service import (
     get_element,
     list_elements,
     update_element_for_user,
+    upsert_snapshot_for_user,
 )
 from app.modules.users.model import User
 
@@ -41,6 +43,30 @@ def list_elements_endpoint(
         page=page,
         limit=limit,
     )
+
+
+@router.put("/snapshot", response_model=ElementResponse)
+def upsert_snapshot_endpoint(
+    body: SnapshotUpsert,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ElementResponse:
+    """Atomic insert-or-update of a board's excalidraw_snapshot element.
+
+    Replaces the old client-side GET-list-then-POST-or-PATCH pattern,
+    which raced under concurrent saves (e.g. a debounced save overlapping
+    a beforeunload save) and could create duplicate snapshot rows for the
+    same board.
+    """
+    element = upsert_snapshot_for_user(db, body.board_id, current_user, body.data)
+    if not element:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Board not found or unauthorized",
+        )
+    resp = ElementResponse.model_validate(element)
+    publish_board_event(str(body.board_id), "element.updated", resp.model_dump(mode="json"))
+    return resp
 
 
 @router.get("/{element_id}", response_model=ElementResponse)

--- a/api/app/app/modules/elements/schemas.py
+++ b/api/app/app/modules/elements/schemas.py
@@ -38,3 +38,8 @@ class ElementListResponse(BaseModel):
 class ElementBulkUpdate(BaseModel):
     board_id: UUID
     updates: List[ElementData]  # [{"id": "uuid", "data": {...}}]
+
+
+class SnapshotUpsert(BaseModel):
+    board_id: UUID
+    data: ElementData = {}

--- a/api/app/app/modules/elements/service.py
+++ b/api/app/app/modules/elements/service.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from app.modules.boards.repository import get_by_id as get_board
-from app.modules.elements.model import Element
+from app.modules.elements.model import Element, ElementData
 from app.modules.elements.repository import (
     bulk_update_data,
     create as create_element,
@@ -12,6 +12,7 @@ from app.modules.elements.repository import (
     get_by_id,
     get_by_board,
     update as update_element,
+    upsert_snapshot,
 )
 from app.modules.elements.schemas import ElementCreate, ElementUpdate
 from app.modules.users.model import User
@@ -74,3 +75,12 @@ def bulk_update_elements(
     if not board or not workspace_is_member(db, board.workspace_id, user.id):
         return None
     return bulk_update_data(db, board_id, updates)
+
+
+def upsert_snapshot_for_user(
+    db: Session, board_id: UUID, user: User, data: ElementData
+) -> Element | None:
+    board = get_board(db, board_id)
+    if not board or not workspace_is_member(db, board.workspace_id, user.id):
+        return None
+    return upsert_snapshot(db, board_id=board_id, data=data)

--- a/apps/frontend/src/hooks/useBoardContent.ts
+++ b/apps/frontend/src/hooks/useBoardContent.ts
@@ -58,30 +58,13 @@ export function useBoardContent(boardId: string | null) {
     async (content: ExcalidrawSnapshot) => {
       if (!boardId) return;
       try {
-        const listRes = await apiFetch(
-          `/api/elements?board_id=${boardId}&page=1&limit=500`,
-        );
-        if (!listRes.ok) return;
-        const listData = await listRes.json();
-        const existing = listData.items?.find(
-          (e: { type: string }) => e.type === SNAPSHOT_TYPE,
-        );
-
-        if (existing) {
-          await apiFetch(`/api/elements/${existing.id}`, {
-            method: "PATCH",
-            body: JSON.stringify({ data: content }),
-          });
-        } else {
-          await apiFetch("/api/elements", {
-            method: "POST",
-            body: JSON.stringify({
-              board_id: boardId,
-              type: SNAPSHOT_TYPE,
-              data: content,
-            }),
-          });
-        }
+        // Atomic upsert server-side -- no GET-then-decide-POST/PATCH step,
+        // so overlapping saves (e.g. a debounced save racing a beforeunload
+        // save) can no longer create duplicate snapshot rows for the board.
+        await apiFetch("/api/elements/snapshot", {
+          method: "PUT",
+          body: JSON.stringify({ board_id: boardId, data: content }),
+        });
       } catch {
         // Silent fail for auto-save
       }


### PR DESCRIPTION
## Summary
`useBoardContent.saveContent` did a GET-list-then-decide-POST-or-PATCH dance with no locking, so two overlapping saves (a debounced save racing a `beforeunload` save, or two tabs open on the same board) could both conclude "no snapshot exists yet" and both insert one -- leaving two `excalidraw_snapshot` rows for the same board with no defined order on which one `loadContent`'s `.find()` picks up.

- New migration `00425b753873`: first collapses any duplicate snapshot rows a board may have already accumulated (keeps the newest, by `updated_at` then `id`), then adds a **partial unique index** on `elements(board_id) WHERE type = 'excalidraw_snapshot'`.
- New `repository.upsert_snapshot()`: a single atomic `INSERT ... ON CONFLICT (board_id) WHERE type = 'excalidraw_snapshot' DO UPDATE`, so concurrent callers can no longer race into duplicate inserts -- Postgres serializes them at the index level.
- New `PUT /api/elements/snapshot` endpoint exposes this (authorized the same way as the other elements endpoints -- board must exist and caller must be a workspace member).
- Frontend: `useBoardContent.saveContent` now just calls the new endpoint directly instead of the old GET-then-branch dance.

## Test plan
- [x] `ruff check .`, `mypy .`, `pytest` -- all clean (39/39 backend tests)
- [x] `npm run lint`, `npm run test` (27/27), `npm run build` -- all clean
- [x] Migration dedup, verified against a real docker-compose Postgres: manually inserted 3 duplicate snapshot rows for one board, ran the migration, confirmed exactly 1 (the newest) remained
- [x] Migration is reversible (`alembic downgrade -1` then `upgrade head` both succeed cleanly)
- [x] Concurrency fix, verified against real Postgres: ran two `upsert_snapshot()` calls from separate DB sessions/threads targeting a **brand-new board with no prior snapshot** (the exact original race) -- confirmed exactly 1 row resulted, every time
- [x] Full browser (Playwright) pass against the real dev server + API: drew a shape on a real board, confirmed the `PUT /api/elements/snapshot` request fires and exactly one element exists afterward; drew a second shape and confirmed the count stays at 1 (update in place, not a new insert)

Fixes #28