### PR TITLE
fix(auth): reject unverified OAuth emails for account linking (account takeover)

### DIFF
--- a/api/app/app/modules/auth/oauth.py
+++ b/api/app/app/modules/auth/oauth.py
@@ -59,20 +59,27 @@ async def get_github_user_info(code: str) -> Dict[str, Any] | None:
             return None
         user_data = user_resp.json()
 
-        # Get email if not public
-        email = user_data.get("email")
-        if not email:
-            emails_resp = await client.get(
-                "https://api.github.com/user/emails",
-                headers={"Authorization": f"Bearer {access_token}"},
+        # The public /user email field has no verification info attached,
+        # so it can't be trusted for account linking -- always check
+        # /user/emails and only use an entry GitHub itself marked verified.
+        # An attacker can add an *unverified* email to their own GitHub
+        # account, so trusting an unverified address here would let them
+        # log in as whoever owns that email in Loomy.
+        email_verified = False
+        emails_resp = await client.get(
+            "https://api.github.com/user/emails",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        email = None
+        if emails_resp.status_code == 200:
+            emails = emails_resp.json()
+            primary = next(
+                (e for e in emails if e.get("primary") and e.get("verified")),
+                next((e for e in emails if e.get("verified")), None),
             )
-            if emails_resp.status_code == 200:
-                emails = emails_resp.json()
-                primary = next(
-                    (e for e in emails if e.get("primary")),
-                    emails[0] if emails else None,
-                )
-                email = primary.get("email") if primary else None
+            if primary:
+                email = primary.get("email")
+                email_verified = True
 
         name = user_data.get("name") or ""
         parts = name.split(None, 1)
@@ -83,6 +90,7 @@ async def get_github_user_info(code: str) -> Dict[str, Any] | None:
             "provider": "github",
             "provider_user_id": str(user_data["id"]),
             "email": email or f"{user_data['id']}@github.user",
+            "email_verified": email_verified,
             "username": user_data.get("login", "user"),
             "avatar_url": user_data.get("avatar_url"),
             "first_name": first_name,
@@ -127,10 +135,22 @@ async def get_google_user_info(code: str) -> Dict[str, Any] | None:
         if not first_name:
             first_name = "User"
 
+        # Google's userinfo response includes `email_verified` per address;
+        # only trust it for account linking when true, same reasoning as
+        # the GitHub path above -- an unverified email must not be usable
+        # to take over an existing account that happens to share it.
+        raw_email = user_data.get("email", "")
+        email_verified = bool(user_data.get("email_verified"))
+        provider_user_id = user_data.get("sub", "")
+        email = raw_email if email_verified and raw_email else (
+            f"{provider_user_id}@google.user"
+        )
+
         return {
             "provider": "google",
-            "provider_user_id": user_data.get("sub", ""),
-            "email": user_data.get("email", ""),
+            "provider_user_id": provider_user_id,
+            "email": email,
+            "email_verified": email_verified and bool(raw_email),
             "username": user_data.get("name", "user").replace(" ", "").lower()[:50],
             "avatar_url": user_data.get("picture"),
             "first_name": first_name,

--- a/api/app/app/modules/auth/router.py
+++ b/api/app/app/modules/auth/router.py
@@ -184,7 +184,10 @@ async def github_callback(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Failed to get user info from GitHub",
         )
-    user, _ = get_or_create_oauth_user(db, info)
+    try:
+        user, _ = get_or_create_oauth_user(db, info)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     token_pair = issue_token_pair(str(user.id))
     raw_invite = state_data.get("invite_token")
     invite_token = raw_invite if isinstance(raw_invite, str) and raw_invite else None
@@ -222,7 +225,10 @@ async def google_callback(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Failed to get user info from Google",
         )
-    user, _ = get_or_create_oauth_user(db, info)
+    try:
+        user, _ = get_or_create_oauth_user(db, info)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     token_pair = issue_token_pair(str(user.id))
     raw_invite = state_data.get("invite_token")
     invite_token = raw_invite if isinstance(raw_invite, str) and raw_invite else None

--- a/api/app/app/modules/auth/service.py
+++ b/api/app/app/modules/auth/service.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Dict, Tuple
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.jwt import (
@@ -74,7 +75,14 @@ def get_or_create_oauth_user(
     if user:
         return user, False
 
-    user = get_by_email(db, info["email"])
+    # Only link to an existing account by email when the provider itself
+    # attests the email is verified. Both GitHub and Google allow an
+    # account to hold an *unverified* email address; trusting that here
+    # would let an attacker add a victim's email to their own OAuth
+    # account and log in as the victim. An unverified/synthetic email
+    # always falls through to creating a brand-new account below instead.
+    email_verified = bool(info.get("email_verified"))
+    user = get_by_email(db, info["email"]) if email_verified else None
     if user:
         create_oauth_account(
             db,
@@ -100,20 +108,33 @@ def get_or_create_oauth_user(
     first_name = info.get("first_name")
     last_name = info.get("last_name")
 
-    user = create_user(
-        db,
-        email=info["email"],
-        username=username,
-        hashed_password=None,
-        avatar_url=info.get("avatar_url"),
-        first_name=first_name,
-        last_name=last_name,
-    )
-    # OAuth provider already verified this email.
-    user.email_verified = True
-    user.email_verified_at = datetime.now(timezone.utc)
-    db.add(user)
-    db.commit()
+    try:
+        user = create_user(
+            db,
+            email=info["email"],
+            username=username,
+            hashed_password=None,
+            avatar_url=info.get("avatar_url"),
+            first_name=first_name,
+            last_name=last_name,
+        )
+    except IntegrityError:
+        # Only reachable when info["email"] wasn't verified (verified
+        # emails would have matched via get_by_email above) and happens
+        # to collide with an existing account's email. Refuse instead of
+        # silently creating a duplicate-email row or linking unverified.
+        db.rollback()
+        raise ValueError(
+            "An account with this email already exists. Sign in with "
+            "your password, or verify this email with the provider "
+            "before linking."
+        ) from None
+
+    if email_verified:
+        user.email_verified = True
+        user.email_verified_at = datetime.now(timezone.utc)
+        db.add(user)
+        db.commit()
 
     create_oauth_account(
         db,


### PR DESCRIPTION
## Summary

Both the GitHub and Google OAuth login flows linked an incoming OAuth identity to an existing local account by email match alone, without checking whether the provider considers that email verified. Both providers allow an account to hold an *unverified* email address, so an attacker could add a victim's Loomy account email to their own GitHub or Google account and log in as the victim via "Sign in with GitHub/Google" -- no password required.

## Changes

- **`api/app/app/modules/auth/oauth.py`**
  - GitHub: only accepts an email from `/user/emails` where `verified: true`. The public `/user.email` field carries no verification guarantee we can safely rely on, so it's no longer used directly.
  - Google: only accepts the userinfo email when `email_verified: true`.
  - Either path falls back to a synthetic, explicitly-unverified placeholder email (`{id}@github.user` / `{sub}@google.user`) otherwise -- same pattern the code already used for GitHub's "no public email" case.
- **`api/app/app/modules/auth/service.py`**
  - `get_or_create_oauth_user` now only looks up/links an existing account by email when `info["email_verified"]` is true. An unverified email always falls through to creating a brand-new account instead of linking.
  - Added a narrow `IntegrityError` guard for the (newly reachable) edge case where an unverified email happens to collide with an existing account's email -- fails cleanly with a 400 instead of a raw 500 or a duplicate-email row.
- **`api/app/app/modules/auth/router.py`**: both OAuth callbacks convert that `ValueError` into an HTTP 400.

## Test plan

- [x] `ruff check .`, `mypy .`, `pytest` -- all clean (39/39 backend tests)
- [x] Verified against a real docker-compose Postgres by calling `get_or_create_oauth_user` directly with crafted provider payloads (no test DB infra exists yet in this repo for auth flows, so this was a direct live verification rather than a new pytest fixture):
  - **Attack payload** (`email_verified=False`, email matching an existing verified local account) -> rejected with a clean `ValueError`, attacker does **not** receive the victim's account
  - **Legitimate payload** (`email_verified=True`, same matching email) -> correctly links to the existing account, as intended for a real user connecting their own verified provider account
  - **Brand-new verified email**, no prior account -> creates a new account and marks it verified, exactly as before this change

Fixes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth email verification for GitHub and Google sign-ins.
  * Unverified email addresses are no longer automatically linked to existing accounts.
  * Added clearer error messages when account creation conflicts occur.
  * OAuth users now receive verified-email status accurately, preventing unverified addresses from being marked as confirmed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->